### PR TITLE
Taboo: Handle KICKOFF messages

### DIFF
--- a/src/Taboo/HostParameters.py
+++ b/src/Taboo/HostParameters.py
@@ -12,7 +12,7 @@ MAX_TEAMS = 4
 MIN_TURN_DURATION = 30
 MAX_TURN_DURATION = 180
 
-MAX_ROUNDS = 8
+MAX_TURNS = 8
 
 class HostParameters:
     """Tracks host parameters for a game
@@ -29,14 +29,14 @@ class HostParameters:
     ctrArgs = ("numTeams",
                "turnDurationSec",
                "wordSets",
-               "numRounds",
+               "numTurns",
               )
 
     def __init__(self,
                  numTeams,
                  turnDurationSec,
                  wordSets,
-                 numRounds):
+                 numTurns):
         self.msgSrc = None
 
         if not isinstance(numTeams, int) or numTeams < MIN_TEAMS or numTeams > MAX_TEAMS:
@@ -50,8 +50,8 @@ class HostParameters:
                 not set(wordSets).issubset(SupportedWordSets)):
             raise InvalidDataException("Invalid type or wordSets", wordSets)
 
-        if (not isinstance(numRounds, int) or numRounds < 1 or numRounds > MAX_ROUNDS):
-            raise InvalidDataException("Invalid type or numRounds", numRounds)
+        if (not isinstance(numTurns, int) or numTurns < 1 or numTurns > MAX_TURNS):
+            raise InvalidDataException("Invalid type or numTurns", numTurns)
 
         vals = locals()
         self.state = Map(**{argName: vals[argName] for argName in self.ctrArgs})

--- a/src/Taboo/README.md
+++ b/src/Taboo/README.md
@@ -55,7 +55,7 @@ Team: [0=auto, 1..T]
 {"numTeams": <int>,         # 1..4
  "turnDurationSec": <int>,  # 30..180
  "wordSets": ["name1", "name2", ...],
- "numRounds": <int>,        # 1..8
+ "numTurns": <int>,        # 1..8
 }
 ```
 
@@ -209,7 +209,7 @@ All connected players hit the ready button (each team must have at least 2 playe
 Client --> start
 
 ```
-["START"]
+["READY"]
 ```
 
 ## Start turn

--- a/src/Taboo/Turn.py
+++ b/src/Taboo/Turn.py
@@ -7,6 +7,10 @@ from fwk.MsgSrc import (
         Jmai,
         MsgSrc,
 )
+from fwk.Trace import (
+        trace,
+        Level,
+)
 
 class WordState(Enum):
     IN_PLAY = 1
@@ -28,6 +32,8 @@ class Turn:
         self._otherTeams = otherTeams
         self._state = state
         self._score = score or [] # list of teamNumbers that should be awarded points
+
+        trace(Level.rnd, "New Turn", str(self))
 
         # Messages are broadcast to everyone connected to the room
         self._publicMsgSrc = MsgSrc(allConns)

--- a/src/Taboo/TurnManager.py
+++ b/src/Taboo/TurnManager.py
@@ -4,6 +4,10 @@ from collections import defaultdict
 from enum import Enum
 import random
 
+from fwk.Msg import (
+        ClientTxMsg,
+        TimerRequest,
+)
 from fwk.Trace import (
         trace,
         Level,
@@ -14,28 +18,60 @@ from Taboo.Turn import (
 )
 
 class TurnState(Enum):
-    START_WAIT = 1
+    KICKOFF_WAIT = 1
     RUNNING = 2
 
 class TurnManager:
-    def __init__(self, txQueue, wordSet, teams, hostNumTurns, allConns):
+    def __init__(self, txQueue, wordSet, teams, hostParameters, allConns):
         self._txQueue = txQueue
         self._wordSet = wordSet
         self._teams = teams
-        self._hostNumTurns = hostNumTurns # Stop the game when every live player
-                                          # has played hostNumTurns
+        self._hostParameters = hostParameters # Stop the game when every live player
+                                              # has played hostParameters.numTurns
         self._allConns = allConns
 
-        self._teamCount = len(self._teams)
-        self._curTurnId = 0
         self._turnById = defaultdict(list)
-        self._curTurn = None
 
-        self._state = TurnState.START_WAIT
+        self._curTurnId = 0
+        self._curTurn = None # Points to the current turn in play
+        self._activePlayer = None
+
+        self._state = TurnState.KICKOFF_WAIT
         self._usedWordIdxs = set() # index of words used from self._wordSet
 
-    def processMsg(self, qmsg):
-        """Handle ALERT, COMPLETED, etc related messages here maybe?"""
+    @property
+    def activePlayer(self):
+        return self._activePlayer
+
+    @property
+    def numTurns(self):
+        return self._hostParameters.numTurns
+
+    @property
+    def turnDurationSec(self):
+        return self._hostParameters.turnDurationSec
+
+    def processKickoff(self, qmsg):
+        """Always returns True (implies message ingested)"""
+        ws = qmsg.initiatorWs
+
+        if self._state != TurnState.KICKOFF_WAIT:
+            self._txQueue.put_nowait(ClientTxMsg(["KICKOFF-BAD",
+                                                  "Can't kickoff a turn"],
+                                                  {ws}, initiatorWs=ws))
+            return True
+
+        # Start with a new word for the activePlayer
+
+        ctx = {"turnId": self._curTurnId}
+        self._txQueue.put_nowait(TimerRequest(self.turnDurationSec, self.timerExpiredCb, ctx))
+
+        assert self.startNextWord() is True, "Must always be able to start a new word"
+        return True
+
+    def timerExpiredCb(self, ctx):
+        """This method is invoked when the timer fires"""
+        trace(Level.info, "Timer fired", ctx)
 
     def _findNextPlayer(self):
         """
@@ -54,9 +90,9 @@ class TurnManager:
             trace(Level.info, "no live players")
             return None
 
-        if not any(any(True for plyr in plyrs if plyr.turnsPlayed < self._hostNumTurns)
+        if not any(any(True for plyr in plyrs if plyr.turnsPlayed < self.numTurns)
                for plyrs in candidatePlayersByTeam.values()):
-            trace(Level.info, "All players have played atleast", self._hostNumTurns, "turns")
+            trace(Level.info, "All players have played atleast", self.numTurns, "turns")
             return None
 
 
@@ -67,9 +103,11 @@ class TurnManager:
             currentTeam = random.choice(list(self._teams.values()))
 
         # Identify nextPlayer (preferring a player from the next team)
-        for teamIdx in [1 + ((ti + currentTeam.teamNumber) % self._teamCount)
-                        for ti in range(self._teamCount)]:
+        teamCount = len(self._teams)
+        for teamIdx in [1 + ((ti + currentTeam.teamNumber) % teamCount)
+                        for ti in range(teamCount)]:
             if teamIdx not in candidatePlayersByTeam:
+                # No live clients in this team
                 continue
 
             nextPlayer = candidatePlayersByTeam[teamIdx][0]
@@ -84,27 +122,35 @@ class TurnManager:
         Returns bool : true if new turn was started; false if the game is over
         """
         # 1. Find next player to go. If none is found, declare end of game
-        nextPlayer = self._findNextPlayer()
-        if not nextPlayer:
+        self._activePlayer = self._findNextPlayer()
+        if not self._activePlayer:
             # TODO handle game over here # pylint: disable=fixme
             trace(Level.rnd, "Can't start a new turn as no next player available")
             return False
 
         # 2. Start a new turn
         self._curTurnId += 1
+        self._curTurn = None # No word selected to start
 
-        return self.startNextWord(nextPlayer)
+        if not self._wordSet.areWordsAvailable(self._usedWordIdxs):
+            trace(Level.rnd, "Words exhausted")
+            return False
 
-    def startNextWord(self, activePlayer):
+        return True
+
+    def startNextWord(self):
         """
         Returns bool : True if new word started; false if the game is over
                        (no more words available)
         """
+        assert self.activePlayer
+        self._state = TurnState.RUNNING
+
         if self._turnById[self._curTurnId]:
-            trace(Level.error,
+            trace(Level.debug,
                   "curTurnId", self._curTurnId,
                   "lastWord", self._turnById[self._curTurnId][-1],
-                  "Can't start new word when previous word is still IN_PLAY")
+                  "state", self._turnById[self._curTurnId][-1].state)
             assert self._turnById[self._curTurnId][-1].state != WordState.IN_PLAY
 
         nextWordId = len(self._turnById[self._curTurnId]) + 1
@@ -118,12 +164,12 @@ class TurnManager:
         self._usedWordIdxs = found.usedWordIdxs
         secret = found.word
         disallowed = found.disallowed
-        trace(Level.rnd, "player", activePlayer.name, "word", secret)
+        trace(Level.rnd, "player", self.activePlayer.name, "word", secret)
 
         # Create a new Turn
         turn = Turn(self._curTurnId, nextWordId, secret, disallowed,
-                    activePlayer, [team for team in self._teams.values()
-                                   if team != activePlayer.team],
+                    self.activePlayer, [team for team in self._teams.values()
+                                   if team != self.activePlayer.team],
                     self._allConns)
         self._turnById[self._curTurnId].append(turn)
 

--- a/src/Taboo/WordSets.py
+++ b/src/Taboo/WordSets.py
@@ -52,6 +52,9 @@ class WordSet:
             return False
         return self.data['enabled']
 
+    def areWordsAvailable(self, usedWordIdxs):
+        return len(usedWordIdxs) < self.count()
+
     def nextWord(self, usedWordIdxs):
         """
         Arguments
@@ -65,7 +68,7 @@ class WordSet:
             Map(word : str, disallowed : list[str],
                 usedWordIdxs : set(int))
         """
-        if len(usedWordIdxs) >= self.count():
+        if not self.areWordsAvailable(usedWordIdxs):
             # No more words
             return None
 

--- a/src/fwk/Msg.py
+++ b/src/fwk/Msg.py
@@ -96,3 +96,14 @@ class InternalGiStatus(MsgBase):
         # pylint: disable=bad-super-call
         return super(self.__class__, self).__str__() + " jmsg=" + str(self.jmsg) + \
                 " fromPath=" + self.fromPath
+
+class TimerRequest(MsgBase):
+    def __init__(self, afterSec, cb, ctx):
+        super(TimerRequest, self).__init__(initiatorWs=None)
+        self.afterSec = afterSec
+        self.cb = cb
+        self.ctx = ctx
+
+    def __str__(self):
+        return str(super(self.__class__, self)) + " afterSec={} cb={} ctx={}".format(
+                self.afterSec, self.cb, self.ctx)


### PR DESCRIPTION
- README.md change: rename "START" to "READY" message
- Added WordSet and TurnManager to TabooRoom
- Added processKickoff handling (full test coverage of the code so far)
- Introduced the notion of TimerRequest that can be made to the
framework
  - There is no handling of such messages in the fwk yet
- Renamed "numRounds" to "numTurns" everywhere