### PR TITLE
Taboo: Change yaml word list to dictionary of words instead of list

### DIFF
--- a/src/Taboo/TabooRoom.py
+++ b/src/Taboo/TabooRoom.py
@@ -51,7 +51,7 @@ class TabooRoom(GamePlugin):
                       for n in range(1, self.hostParameters.numTeams + 1)}
 
         wordSet = SupportedWordSets[self.hostParameters.wordSets[0]]
-        self.turnMgr = TurnManager(self.txQueue, wordSet,
+        self.turnMgr = TurnManager(self.path, self.txQueue, wordSet,
                                    self.teams, self.hostParameters,
                                    self.conns, self._gameOver)
 
@@ -127,7 +127,7 @@ class TabooRoom(GamePlugin):
 
         return False
 
-    def __valdiateCompletedOrDiscard(self, qmsg):
+    def __validateCompletedOrDiscard(self, qmsg):
         """ Validates [COMPLETED|DISCARD, turn<int>, wordIdx<int>]
         Replies a DISCARD-BAD or COMPLETED-BAD if the message is incorrect,
         or if the message is received at wrong game state
@@ -174,7 +174,7 @@ class TabooRoom(GamePlugin):
         """
         ["DISCARD|COMPLETED", turn<int>, wordIdx<int>]
         """
-        if not self.__valdiateCompletedOrDiscard(qmsg):
+        if not self.__validateCompletedOrDiscard(qmsg):
             return True
         return self.turnMgr.processCompletedOrDiscard(qmsg)
 

--- a/src/Taboo/wordsets/test
+++ b/src/Taboo/wordsets/test
@@ -1,11 +1,11 @@
 enabled: true
 words:
-   - a:
+   a:
       - a1
       - a2
-   - b:
+   b:
       - b1
       - b2
-   - c:
+   c:
       - c1
       - c2


### PR DESCRIPTION
Closes #44
- Change wordset's list of words to dictionary of words
- Changed wordset API to take requestor name instead of usedWordIdxs (TurnMgr doesn't have to manage this anymore)
- Changed tests to not rely on random.seed(1). The rewrite is an ugly hack and I think I have lost coverage of _findNextPlayer. Will address that in the future.