### PR TITLE
Taboo: Clear IN_PLAY messages before destroying privateMsgSrc

### DIFF
--- a/src/Taboo/Word.py
+++ b/src/Taboo/Word.py
@@ -98,6 +98,7 @@ class Word:
 
         # If the turn isn't in play, there is no private messaging needed.
         if self._privateMsgSrc:
+            self._privateMsgSrc.setMsgs([]) # Reset previous messages
             self._privateMsgSrc = None
 
         msg = ["TURN", self._turnId, self._wordId,

--- a/src/fwk/ServerQueueTask.py
+++ b/src/fwk/ServerQueueTask.py
@@ -133,5 +133,6 @@ class Timer:
         trace(Level.msg, "Starting sleep for", self._qmsg)
         await asyncio.sleep(self._qmsg.afterSec)
         trace(Level.msg, "Firing callback for", self._qmsg)
-        await self._qmsg.cb(self._qmsg.ctx)
+        self._qmsg.cb(self._qmsg.ctx)
+        trace(Level.msg, "Callback returned for", self._qmsg)
         del timerByQmsg[self._qmsg] # This is funky? Losing reference to self


### PR DESCRIPTION
We were deleting the privateMsgSrc which sends the IN_PLAY message with
secret to select few but not clearing the messages set in it.

Closes #45